### PR TITLE
Make the analysis annotation directed

### DIFF
--- a/clang/include/clang/Analysis/Analyses/LifetimePsetBuilder.h
+++ b/clang/include/clang/Analysis/Analyses/LifetimePsetBuilder.h
@@ -33,7 +33,7 @@ void VisitBlock(PSetsMap &PMap, llvm::Optional<PSetsMap> &FalseBranchExitPMap,
 void getLifetimeContracts(PSetsMap &PMap, const FunctionDecl *FD,
                           const ASTContext &ASTCtxt,
                           IsConvertibleTy isConvertible,
-                          LifetimeReporterBase &Reporter);
+                          LifetimeReporterBase &Reporter, bool Pre = true);
 } // namespace lifetime
 } // namespace clang
 

--- a/clang/include/clang/Analysis/Analyses/LifetimeTypeCategory.h
+++ b/clang/include/clang/Analysis/Analyses/LifetimeTypeCategory.h
@@ -71,15 +71,6 @@ inline QualType getPointeeType(QualType QT) {
   return classifyTypeCategory(QT).PointeeType;
 }
 
-struct CallTypes {
-  const FunctionProtoType *FTy = nullptr;
-  const CXXRecordDecl *ClassDecl = nullptr;
-};
-
-/// Obtains the function prototype (without 'this' pointer) and the type of
-/// the object (if MemberCallExpr).
-CallTypes getCallTypes(const Expr *CalleeE);
-
 bool isLifetimeConst(const FunctionDecl *FD, QualType Pointee, int ArgNum);
 } // namespace lifetime
 } // namespace clang

--- a/clang/include/clang/Basic/Attr.td
+++ b/clang/include/clang/Basic/Attr.td
@@ -2801,6 +2801,7 @@ public:
     // return value can also be represented if `Baseindex == ReturnVal`.
     unsigned BaseIndex;
     const static unsigned ReturnVal = ~0;
+    const static unsigned ThisVal = ReturnVal - 1;
     llvm::SmallVector<const FieldDecl *, 4> FDs;
   };
   struct PointsToSet {

--- a/clang/test/Sema/attr-psets-annotation.cpp
+++ b/clang/test/Sema/attr-psets-annotation.cpp
@@ -212,6 +212,10 @@ void p4(int *a, int *b, int *&c)
 int *p5(int *a, int *b) { return a; }
 int *p6(int *a, int *b)
     [[gsl::post(pset(Return) == pset(a))]] { return a; }
+struct S{
+  int *f(int * a, int *b, int *&c) { return a; }
+  S *g(int * a, int *b, int *&c) { return this; }
+};
 // TODO: contracts for function pointers?
 
 void f() {
@@ -260,6 +264,21 @@ void f() {
   // expected-warning@-1 {{pset(Pre(a)) = ((*a), (null))}}
   // expected-warning@-2 {{pset(Pre(b)) = ((*b), (null))}}
   // expected-warning@-3 {{pset(Post(Return)) = ((*a), (null))}}
-  
+  __lifetime_contracts(&S::f);
+  // expected-warning@-1 {{pset(Pre(a)) = ((*a), (null))}}
+  // expected-warning@-2 {{pset(Pre(b)) = ((*b), (null))}}
+  // expected-warning@-3 {{pset(Pre(c)) = ((*c))}}
+  // expected-warning@-4 {{pset(Pre(*c)) = ((invalid))}}
+  // expected-warning@-5 {{pset(Pre(This)) = ((*this))}}
+  // expected-warning@-6 {{pset(Post(*c)) = ((*a), (*b), (null))}}
+  // expected-warning@-7 {{pset(Post(Return)) = ((*a), (*b), (null))}}
+  __lifetime_contracts(&S::g);
+  // expected-warning@-1 {{pset(Pre(a)) = ((*a), (null))}}
+  // expected-warning@-2 {{pset(Pre(b)) = ((*b), (null))}}
+  // expected-warning@-3 {{pset(Pre(c)) = ((*c))}}
+  // expected-warning@-4 {{pset(Pre(*c)) = ((invalid))}}
+  // expected-warning@-5 {{pset(Pre(This)) = ((*this))}}
+  // expected-warning@-6 {{pset(Post(*c)) = ((*a), (*b), (null))}}
+  // expected-warning@-7 {{pset(Post(Return)) = ((*this))}}
 }
 } // namespace dump_contracts


### PR DESCRIPTION
The function call modeling is reworked to only look at the annotations
and do not try to use any other heuristics. This has several advantages
over the current design:
  1. Since we use the annotations both for assumptions and checks it is
     guaranteed that we assume the same preconditions that we check at
     the call site.
  2. If the user overwrites the default annotations it will just work.
     (Modulo bugs in the annotation inference and parsing.)
  3. The responsibilities are separated. So the code that infers the
     default annotations are no longer entangled with the analysis code.
  4. This design will help us implement proper pre- and postcondition
     checks, i.e.: warn if there is an unexpected element in the
     argument or the returned value's pset.

The basic design is the following:
  All the contracts are formulated in terms of formal parameters. We
  need to rewrite those contracts (akin to parameter binding) to be able
  to check them against the arguments for function calls.

Challenges:
  It is not clear how the output binding should happen. By default a
  function like: int *f(int *p); might return null pointer.
  Should we assume that f only returns null pointer when its argument is
  null? This is a crucial question that we should answer soon.

  The problem is, if we assume that f only returns null if the argument
  is null then the user has no way to ever force null checking on the
  result of a function (or maybe only with an annotation like nullable?
  but definitely not with contracts.) If we assume that f always can
  return null regardless of its inputs we will force the user to have
  redundant null checks.

  The problem is that there are two separate contracts. One meaning the
  function might return null regardless of its inputs and the other is
  the function might return null depending on its inputs. The question
  is what is the semantics we want for our annotation or if we want both
  how will the user differentiate between them. E.g.: if we add a
  dependent null annotation should the user be able to tell which are
  the arguments on which the nullness of an output depends on?