### PR TITLE
Klein.supress lifetime issue #71

### DIFF
--- a/clang/lib/Analysis/Lifetime.cpp
+++ b/clang/lib/Analysis/Lifetime.cpp
@@ -309,9 +309,8 @@ void runAnalysis(const FunctionDecl *Func, ASTContext &Context,
     return;
   if (Func->isInStdNamespace())
     return;
-  if (shouldSuppressLifetime(Func)) {
+  if (shouldSuppressLifetime(Func))
     return;
-  }
   if (const auto *DC = Func->getEnclosingNamespaceContext())
     if (const auto *NS = dyn_cast<NamespaceDecl>(DC))
       if (NS->getIdentifier() && NS->getName() == "gsl")

--- a/clang/test/Sema/attr-lifetime-suppress.cpp
+++ b/clang/test/Sema/attr-lifetime-suppress.cpp
@@ -1,42 +1,23 @@
 // RUN: %clang_cc1 -fcxx-exceptions -fsyntax-only -verify -Wlifetime -Wno-dangling %s
 
-namespace {
-template <class T>
-class [[gsl::Owner(T *)]] unique_ptr {
-public:
-  unique_ptr(T * t) : t(t) {}
-
-  T *release() {
-    T *tmp = t;
-    t = nullptr;
-    return tmp;
-  }
-
-  T *t = nullptr;
-};
-
-class PrivateKey {
-  // A random class that models a private key.
-};
-} // namespace
-
 namespace nosuppressOnFunction {
-PrivateKey *getPrivateKey() {
-  return unique_ptr<PrivateKey>(new PrivateKey()).release(); // expected-warning {{returning a dangling pointer}}
-  // expected-note@-1 {{temporary was destroyed at the end of the full expression}}
+int *f() {
+  int *p; // expected-note {{it was never initialized here}}
+  return p; // expected-warning {{returning a dangling pointer}}
 }
 } // namespace nosuppressOnFunction
 
 namespace suppressOnFunction {
 
-[[gsl::suppress("lifetime")]] PrivateKey *getPrivateKey() {
-  return unique_ptr<PrivateKey>(new PrivateKey()).release(); // OK
+[[gsl::suppress("lifetime")]] int *f() {
+  int *p;
+  return p; // OK
 }
 
 namespace suppressNotLifetime {
-[[gsl::suppress("notLifetime")]] PrivateKey *getPrivateKey() {
-  return unique_ptr<PrivateKey>(new PrivateKey()).release(); // expected-warning {{returning a dangling pointer}}
-  // expected-note@-1 {{temporary was destroyed at the end of the full expression}}
+[[gsl::suppress("notLifetime")]] int *f() {
+  int *p; // expected-note {{it was never initialized here}}
+  return p; // expected-warning {{returning a dangling pointer}}
 }
 } // namespace suppressNotLifetime
 } // namespace suppressOnFunction

--- a/clang/test/Sema/attr-lifetime-suppress.cpp
+++ b/clang/test/Sema/attr-lifetime-suppress.cpp
@@ -1,0 +1,42 @@
+// RUN: %clang_cc1 -fcxx-exceptions -fsyntax-only -verify -Wlifetime -Wno-dangling %s
+
+namespace {
+template <class T>
+class [[gsl::Owner(T *)]] unique_ptr {
+public:
+  unique_ptr(T * t) : t(t) {}
+
+  T *release() {
+    T *tmp = t;
+    t = nullptr;
+    return tmp;
+  }
+
+  T *t = nullptr;
+};
+
+class PrivateKey {
+  // A random class that models a private key.
+};
+} // namespace
+
+namespace nosuppressOnFunction {
+PrivateKey *getPrivateKey() {
+  return unique_ptr<PrivateKey>(new PrivateKey()).release(); // expected-warning {{returning a dangling pointer}}
+  // expected-note@-1 {{temporary was destroyed at the end of the full expression}}
+}
+} // namespace nosuppressOnFunction
+
+namespace suppressOnFunction {
+
+[[gsl::suppress("lifetime")]] PrivateKey *getPrivateKey() {
+  return unique_ptr<PrivateKey>(new PrivateKey()).release(); // OK
+}
+
+namespace suppressNotLifetime {
+[[gsl::suppress("notLifetime")]] PrivateKey *getPrivateKey() {
+  return unique_ptr<PrivateKey>(new PrivateKey()).release(); // expected-warning {{returning a dangling pointer}}
+  // expected-note@-1 {{temporary was destroyed at the end of the full expression}}
+}
+} // namespace suppressNotLifetime
+} // namespace suppressOnFunction


### PR DESCRIPTION
Ignore functions with the [[gsl::suppress("lifetime")]] attribute during lifetime analysis.
Currently the suppress is only implemented on function level.