### PR TITLE
Allow non existing PSets for MTE #69

### DIFF
--- a/clang/lib/Analysis/LifetimePsetBuilder.cpp
+++ b/clang/lib/Analysis/LifetimePsetBuilder.cpp
@@ -1320,12 +1320,13 @@ void PSetsBuilder::VisitBlock(const CFGBlock &B,
         eraseVariable(nullptr, S->getEndLoc());
       }
       if (!isa<Expr>(S)) {
-        // Clean up PSets for subexpressions. We should never reference
-        // subexpressions again after the full expression ended. The
-        // problem is, it is not trivial to find out the end of a full
-        // expression with linearized CFGs. Just after the
-        // ExprWithCleanups node we might still need the resulting
-        // RValue, thus PSetsOfExpr is not always cleaned.
+        // Clean up P- and RefersTo-sets for subexpressions.
+        // We should never reference subexpressions again after
+        // the full expression ended. The problem is,
+        // it is not trivial to find out the end of a full
+        // expression with linearized CFGs.
+        // This is why currently the sets are only cleared for
+        // statements which are not expressions.
         // TODO: clean this up by properly tracking end of full exprs.
         RefersTo.clear();
         PSetsOfExpr.clear();

--- a/clang/lib/Analysis/LifetimePsetBuilder.cpp
+++ b/clang/lib/Analysis/LifetimePsetBuilder.cpp
@@ -1319,7 +1319,7 @@ void PSetsBuilder::VisitBlock(const CFGBlock &B,
         // Remove all materialized temporaries that are not extended.
         eraseVariable(nullptr, S->getEndLoc());
       }
-      if (isa<Stmt>(S) && !isa<Expr>(S)) {
+      if (!isa<Expr>(S)) {
         // Clean up PSets for subexpressions. We should never reference
         // subexpressions again after the full expression ended. The
         // problem is, it is not trivial to find out the end of a full

--- a/clang/lib/Analysis/LifetimePsetBuilder.cpp
+++ b/clang/lib/Analysis/LifetimePsetBuilder.cpp
@@ -842,6 +842,8 @@ public:
 
   PSet getPSet(const Expr *E, bool AllowNonExisting = false) {
     E = IgnoreTransparentExprs(E);
+    if (!AllowNonExisting)
+      AllowNonExisting = isa<MaterializeTemporaryExpr>(E);
     if (E->isLValue()) {
       auto I = RefersTo.find(E);
       if (I != RefersTo.end())


### PR DESCRIPTION
Materialize Temporary Expr don't always have a pset in the RefersTo or
PSetsOfExpr Maps.
In the example that showed the issue the MaterializeTemporaryExpr
was bound to an integer literal.